### PR TITLE
Unread bar dark theme

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,6 +13,7 @@ create_zip() {
   fi
 }
 
+script_dir="$(dirname "${BASH_SOURCE[0]}")"
 dist_name="$1"
 
 if [[ ! "$dist_name" ]]; then
@@ -20,4 +21,4 @@ if [[ ! "$dist_name" ]]; then
   exit 1
 fi
 
-create_zip "../dist/$dist_name.tdesktop-theme" "../src/*"
+create_zip "$script_dir/../dist/$dist_name.tdesktop-theme" "$script_dir/../src/*"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,7 +9,7 @@ create_zip() {
   if [[ $(which winrar 2>/dev/null) ]]; then
     winrar a -afzip -ep1 "$1" "$2"
   else
-    zip -9 -r "$1" "$2"
+    zip -9 -r -j "$1" $2
   fi
 }
 
@@ -20,4 +20,4 @@ if [[ ! "$dist_name" ]]; then
   exit 1
 fi
 
-create_zip "./dist/$dist_name.tdesktop-theme" "./src/*"
+create_zip "../dist/$dist_name.tdesktop-theme" "../src/*"

--- a/src/colors.tdesktop-theme
+++ b/src/colors.tdesktop-theme
@@ -431,7 +431,7 @@ dialogsVerifiedIconFg: windowFgActive; // todo
 dialogsSendingIconFg: #c1c1c1; // todo
 dialogsSentIconFg: _tnGreen;
 dialogsUnreadBg: windowBgActive; // todo
-dialogsUnreadBgMuted: _tnForeground;
+dialogsUnreadBgMuted: _tnBackgroundLight20;
 dialogsUnreadFg: windowFgActive; // todo
 dialogsBgOver: windowBgOver; // todo
 dialogsNameFgOver: _tnForeground;

--- a/src/colors.tdesktop-theme
+++ b/src/colors.tdesktop-theme
@@ -489,7 +489,7 @@ historySendingInvertedIconFg: #ffffffc8; // todo
 historySystemBg: #89a0b47f; // todo
 historySystemBgSelected: #bbc8d4a2; // todo
 historySystemFg: windowFgActive; // todo
-historyUnreadBarBg: #fcfbfa; // todo
+historyUnreadBarBg: _tnBackgroundLight10; // todo
 historyUnreadBarBorder: shadowFg; // todo
 historyUnreadBarFg: #538bb4; // todo
 historyForwardChooseBg: #0000004c; // todo


### PR DESCRIPTION
Previous unread bar is from default white color scheme.
![before](https://cloud.githubusercontent.com/assets/8620539/22391573/d7ec8ae2-e4a6-11e6-97f0-af10814c05bb.png)

I changed it to the same is InMsgBg. Might not be perfect but it's easier on the eyes and fits the theme more.
![after](https://cloud.githubusercontent.com/assets/8620539/22391575/d9ec6fe2-e4a6-11e6-88c9-89fd880fef4e.png)

Edit: I also changed the bash script so running `./build.sh <name>` right in the scripts directory would work, and the wildcard's wouldn't interfere with creating the zip.